### PR TITLE
fix: use fork instead of spawn on npminstall mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "giturl": "^1.0.0",
     "npm": "^3.10.8",
     "npm-request": "^1.0.0",
+    "npminstall": "^2.7.0",
     "open": "^0.0.5",
-    "urllib": "^2.17.0",
-    "npminstall": "^2.7.0"
+    "urllib": "^2.17.0"
   },
   "devDependencies": {
     "autod": "^2.7.1",

--- a/test/custom-installer.test.js
+++ b/test/custom-installer.test.js
@@ -16,8 +16,6 @@ describe('test/custom-installer.test.js', () => {
     const args = [ 'i', '--by=npm' ];
     if (RUN_ON_CI) {
       args.push('--registry=https://registry.npmjs.org');
-      args.push('--disturl=none');
-      args.push('--userconfig=none');
     }
 
     const testRE = process.platform === 'win32' ? /\\node_modules\\\.bin\\npm/ : /\/node_modules\/\.bin\/npm i/;


### PR DESCRIPTION
can fix install cnpm itself fail on Windows