### PR TITLE
fix: downgrade commander to 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "auto-correct": "^1.0.0",
     "bagpipe": "^0.3.5",
     "colors": "^1.1.2",
-    "commander": "^2.9.0",
+    "commander": "~2.10.0",
     "cross-spawn": "~0.2.8",
     "debug": "^2.2.0",
     "giturl": "^1.0.0",

--- a/test/cnpm.test.js
+++ b/test/cnpm.test.js
@@ -5,6 +5,7 @@ var should = require('should');
 var path = require('path');
 var fs = require('fs');
 var fse = require('fs-extra');
+var coffee = require('coffee');
 var cnpm = path.join(__dirname, '..', 'bin', 'cnpm');
 var fixtures = path.join(__dirname, 'fixtures');
 var cwd = path.join(fixtures, 'foo');
@@ -20,6 +21,14 @@ function run(args, callback) {
 describe('test/cnpm.test.js', () => {
   after(() => {
     fse.removeSync(path.join(cwd, 'node_modules'));
+  });
+
+  it('should version', () => {
+    return coffee.fork(cnpm, [ '-v' ])
+      .debug()
+      .expect('stdout', /cnpm@\d+\.\d+\.\d+ \(/)
+      .expect('code', 0)
+      .end();
   });
 
   it('should show all cnpm config', function (done) {


### PR DESCRIPTION
commander@2.11.0 is a broken change release
see https://github.com/tj/commander.js/issues/659

closes https://github.com/cnpm/cnpm/issues/210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/cnpm/211)
<!-- Reviewable:end -->
