### PR TITLE
fix: downgrade commander to 2.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - '4'
   - '6'
-  - '7'
+  - '8'
 install:
   - npm i npminstall && npminstall
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    #- nodejs_version: '4'
+    - nodejs_version: '4'
     - nodejs_version: '6'
-    - nodejs_version: '7'
+    - nodejs_version: '8'
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -11,6 +11,6 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run ci
+  - npm run test
 
 build: off

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "auto-correct": "^1.0.0",
     "bagpipe": "^0.3.5",
     "colors": "^1.1.2",
-    "commander": "^2.9.0",
+    "commander": "~2.10.0",
     "cross-spawn": "~0.2.8",
     "debug": "^2.2.0",
     "giturl": "^1.0.0",
@@ -44,8 +44,7 @@
     "web": "https://github.com/cnpm/cnpm"
   },
   "bugs": {
-    "url": "https://github.com/cnpm/cnpm/issues",
-    "email": "m@fengmk2.com"
+    "url": "https://github.com/cnpm/cnpm/issues"
   },
   "publishConfig": {
     "tag": "latest-4"
@@ -59,8 +58,8 @@
     "node": ">= 4.0.0"
   },
   "ci": {
-    "version": "4, 6, 7"
+    "version": "4, 6, 8"
   },
-  "author": "fengmk2 <m@fengmk2.com> (http://fengmk2.com)",
+  "author": "fengmk2 <fengmk2@gmail.com> (https://fengmk2.com)",
   "license": "MIT"
 }

--- a/test/cnpm.test.js
+++ b/test/cnpm.test.js
@@ -5,6 +5,7 @@ var should = require('should');
 var path = require('path');
 var fs = require('fs');
 var fse = require('fs-extra');
+var coffee = require('coffee');
 var cnpm = path.join(__dirname, '..', 'bin', 'cnpm');
 var fixtures = path.join(__dirname, 'fixtures');
 var cwd = path.join(fixtures, 'foo');
@@ -20,6 +21,14 @@ function run(args, callback) {
 describe('test/cnpm.test.js', () => {
   after(() => {
     fse.removeSync(path.join(cwd, 'node_modules'));
+  });
+
+  it('should version', () => {
+    return coffee.fork(cnpm, [ '-v' ])
+      .debug()
+      .expect('stdout', /cnpm@\d+\.\d+\.\d+ \(/)
+      .expect('code', 0)
+      .end();
   });
 
   it('should show all cnpm config', function (done) {


### PR DESCRIPTION
commander@2.11.0 is a broken change release
see https://github.com/tj/commander.js/issues/659

closes https://github.com/cnpm/cnpm/issues/210

pick from https://github.com/cnpm/cnpm/pull/211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/cnpm/212)
<!-- Reviewable:end -->
