### PR TITLE
feat: upgrade open@^8, npminstall@^5, node@>=10

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "ini": "^1.3.4",
     "npm": "^6.13.4",
     "npm-request": "^1.0.0",
-    "npminstall": "^3.25.2",
-    "open": "^0.0.5",
+    "npminstall": "^5.0.0",
+    "open": "^8.2.1",
     "urllib": "^2.17.0"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
     "tag": "latest-6"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 10.0.0"
   },
   "ci": {
     "type": "github",


### PR DESCRIPTION
- upgrade `open@^8` to fix potential security vulnerabilities
- upgrade `npminstall@^5` to support npm alias
- upgrade `node@>=10` to support npm alias
- a major version bump is needed