### PR TITLE
feat: bundle deps of cnpm

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,3 @@ jobs:
     with:
       os: 'ubuntu-latest, macos-latest, windows-latest'
       version: '14.18.0, 14, 16, 18, 20'
-      # npm install npm will be fail on Windows with Node.js 14.x, use npminstall instead
-      # see https://github.com/npm/cli/issues/4438
-      install: 'npm i -g npminstall && npminstall'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,19 @@
     "lint": "eslint bin/* lib test/*.test.js",
     "ci": "npm run lint && egg-bin test"
   },
+  "bundleDependencies": [
+    "auto-correct",
+    "bagpipe",
+    "commander",
+    "cross-spawn",
+    "giturl",
+    "ini",
+    "npm",
+    "npm-request",
+    "npminstall",
+    "open",
+    "urllib"
+  ],
   "dependencies": {
     "auto-correct": "^1.0.0",
     "bagpipe": "^0.3.5",


### PR DESCRIPTION
> 修改构建配置，将 cnpm 运行依赖进行 bundle 处理，see https://github.com/nodejs/corepack/pull/333

1. 期望 cnpm 能直接集成在 corepack 中作为 nodejs 预置的包管理器
2. 目前其他 pnpm、npm 和 yarn 都会做 bundle 处理，cnpm 由于集成了 npm，只能继续使用 bundleDeps 的方式打包

corepack 通过 tgz 进行分发， 没有时机执行相关依赖安装。

尝试过两种方式进行 bundle:
1. ❎ 通过 esbuild，无法处理 require.resolve npm 的场景，考虑到依赖稳定性需要将 npm 一并 bundle
2. ✅ 通过 bundleDeps 配置

两种方式都需要通过 `npm` mode 进行安装

目前 bundle 后 tgz 体积为 `8.7M`，和 pnpm，yarn 相比差距较大 (~2M)