### PR TITLE
fix: bundle bin

### DIFF
--- a/lib/origin_npm.js
+++ b/lib/origin_npm.js
@@ -89,7 +89,10 @@ if (isInstall) {
   args.unshift('--china');
   args.unshift('--fix-bug-versions');
 } else {
-  npmBin = path.join(__dirname, '..', 'node_modules', '.bin', 'npm');
+  // https://github.com/npm/cli/issues/2491
+  // bundleDeps will not auto create node_modules/.bin/npm-cli
+  // cnpm run dev will failed in corepack
+  npmBin = path.join(require.resolve('npm'), '..', 'bin', 'npm-cli.js');
 }
 
 debug('%s %s', npmBin, args.join(' '));


### PR DESCRIPTION
* 更新 npmBin 获取方式，默认不依赖 node_module/.bin 中的声明
* 兼容 corepack 场景独立解压安装场景