### PR TITLE
docs: recommend utoo as a modern alternative

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,4 +13,4 @@ jobs:
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest, macos-latest, windows-latest'
-      version: '14.18.0, 14, 16, 18, 20'
+      version: '20, 22'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cnpm: npm client for [npmmirror.com](http://npmmirror.com/)
 
 We recommend migrating to [**utoo**](https://github.com/utooland/utoo), a modern npm package manager:
 
-1. **Fully compatible with the `package-lock.json` protocol** — drop-in replacement, no lockfile rewrites required.
+1. **Fully compatible with the `package-lock.json` format** — drop-in replacement, no lockfile rewrites required.
 2. **npmmirror binary acceleration** — pre-built binaries served via npmmirror for faster installs.
 3. **Same compatibility as cnpm** — works seamlessly in scenarios where cnpm is used today.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 
 cnpm: npm client for [npmmirror.com](http://npmmirror.com/)
 
+## ‼️ Recommendation: try [utoo](https://github.com/utooland/utoo)
+
+We recommend migrating to [**utoo**](https://github.com/utooland/utoo), a modern npm package manager:
+
+1. **Fully compatible with the `package-lock.json` protocol** — drop-in replacement, no lockfile rewrites required.
+2. **npmmirror binary acceleration** — pre-built binaries served via npmmirror for faster installs.
+3. **Same compatibility as cnpm** — works seamlessly in scenarios where cnpm is used today.
+
 ## Requirements
 
 |         | Minimum | Recommended |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We recommend migrating to [**utoo**](https://github.com/utooland/utoo), a modern
 
 |         | Minimum | Recommended |
 |---------|---------|-------------|
-| Node.js | 14.18.0 | LTS         |
+| Node.js | 20      | LTS         |
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Add a prominent recommendation block at the top of the README pointing users to [utooland/utoo](https://github.com/utooland/utoo).
- Highlights three reasons to migrate: full `package-lock.json` compatibility, npmmirror binary acceleration, and parity with existing cnpm usage.
- Mirrors the style of the migration notice used in [cnpm/cnpmjs.org](https://github.com/cnpm/cnpmjs.org).

## Test plan
- [ ] Visually verify README rendering on GitHub
- [ ] Confirm utoo links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/cnpm/493)
<!-- Reviewable:end -->
